### PR TITLE
Пофіксив сторінку з відео

### DIFF
--- a/src/js/02-video.js
+++ b/src/js/02-video.js
@@ -5,10 +5,10 @@ const iframe = document.querySelector('iframe');
 const player = new Vimeo.Player(iframe);
 
 const onPlay = function(data) {
-    localStorage.setItem(videoplayer-current-time, data.seconds)
-    console.log("Current time :" , localStorage.getItem(videoplayer-current-time))
+    localStorage.setItem("videoplayer-current-time", data.seconds);
+    console.log("Current time :" , localStorage.getItem("videoplayer-current-time"));
 };
     
-player.setCurrentTime(localStorage.getItem("videoplayer-current-time"))
+player.setCurrentTime(localStorage.getItem("videoplayer-current-time") || 0);
 
-player.on('timeupdate', throttle(onPlay, 1000))
+player.on('timeupdate', throttle(onPlay, 1000));


### PR DESCRIPTION
Коли користувач вперше заходив на сайт в нього ще не було збереженого `videoplayer-current-time` і функція бачила заміть того всього `undefined`. Тепер якщо в користувача нема `videoplayer-current-time` функція буде примати 0, а не `undefined`.
Ну і кілька синтаксичних помилок виправив.

**_Легчайшая для величайшого_**